### PR TITLE
Adding Umpire toolchain host config files

### DIFF
--- a/gitlab/conf/host-configs/bgqos_0/clang_4_0_0.cmake
+++ b/gitlab/conf/host-configs/bgqos_0/clang_4_0_0.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/apps/gnu/clang/r284961-stable/bin/bgclang++11" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/apps/gnu/clang/r284961-stable/bin/bgclang" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_3_9_1.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_3_9_1.cmake
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tcetmp/packages/clang/clang-3.9.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tcetmp/packages/clang/clang-3.9.1/bin/clang" CACHE PATH "")
 
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_4_0_0.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_4_0_0.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tcetmp/packages/clang/clang-4.0.0/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tcetmp/packages/clang/clang-4.0.0/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_9_0_0.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_9_0_0.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-9.0.0/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-9.0.0/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003" CACHE PATH "")
+set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_06_29.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_06_29.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_08_31.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_08_31.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_06.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_06.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_18.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_coral_2017_09_18.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_default.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/clang_default.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003" CACHE PATH "")
+set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_4_9_3.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_4_9_3.cmake
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")
 

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_8_3_1.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_8_3_1.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran" CACHE PATH "")
+

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_default.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/gcc_default.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "gfortran" CACHE PATH "")
+

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_06_29.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_06_29.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.06.29/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_08_31.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_08_31.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.08.31/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_06.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_06.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.06/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_18.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_clang_coral_2017_09_18.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-coral-2017.09.18/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
+
 set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
 set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
 set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_gcc_4_9_3.cmake
@@ -5,6 +5,6 @@
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
 
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_xl-beta-2017.09.13.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/nvcc_xl-beta-2017.09.13.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlC_r" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlc_r" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-beta-2017.09.13/bin/xlf2003_r" CACHE PATH "")

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/pgi_default.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/pgi_default.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "pgc++" CACHE PATH "")
+set(CMAKE_C_COMPILER "pgcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "pgfortran" CACHE PATH "")
+

--- a/gitlab/conf/host-configs/blueos_3_ppc64le_ib/xl_default.cmake
+++ b/gitlab/conf/host-configs/blueos_3_ppc64le_ib/xl_default.cmake
@@ -1,0 +1,10 @@
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+##############################################################################
+set(CMAKE_CXX_COMPILER "xlc++" CACHE PATH "")
+set(CMAKE_C_COMPILER "xlc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "xlf2003" CACHE PATH "")
+

--- a/gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_8_1.cmake
+++ b/gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_8_1.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.8.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.8.1/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_9_1.cmake
+++ b/gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_3_9_1.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.9.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-3.9.1/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_4_0_0.cmake
+++ b/gitlab/conf/host-configs/chaos_5_x86_64_ib/clang_4_0_0.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-4.0.0/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/global/tools/clang/chaos_5_x86_64_ib/clang-4.0.0/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/chaos_5_x86_64_ib/cudatoolkit_8_0.cmake
+++ b/gitlab/conf/host-configs/chaos_5_x86_64_ib/cudatoolkit_8_0.cmake
@@ -4,7 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-

--- a/gitlab/conf/host-configs/chaos_5_x86_64_ib/gcc_4_9_3.cmake
+++ b/gitlab/conf/host-configs/chaos_5_x86_64_ib/gcc_4_9_3.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/apps/gnu/4.9.3/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/apps/gnu/4.9.3/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_16_0_258.cmake
+++ b/gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_16_0_258.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/local/bin/icpc-16.0.258" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/local/bin/icc-16.0.258" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/local/bin/ifort-16.0.258" CACHE PATH "")

--- a/gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_17_0_174.cmake
+++ b/gitlab/conf/host-configs/chaos_5_x86_64_ib/icpc_17_0_174.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/local/bin/icpc-17.0.174" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/local/bin/icc-17.0.174" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/local/bin/ifort-17.0.174" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/clang_3_9_1.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/clang_3_9_1.cmake
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
 
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-3.9.1/bin/clang++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-3.9.1/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/clang_4_0_0.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/clang_4_0_0.cmake
@@ -1,9 +1,9 @@
-###############################################################################
-# Copyright (c) 2019, Lawrence Livermore National Security, LLC and other
-# RADIUSS-CI project contributors. See top-level COPYRIGHT file for details.
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: MIT
-###############################################################################
-
+# SPDX-License-Identifier: (MIT)
+##############################################################################
 set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-4.0.0/bin/clang++" CACHE PATH "")
 set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-4.0.0/bin/clang" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/cudatoolkit_9_1.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/cudatoolkit_9_1.cmake
@@ -4,7 +4,3 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_4_9_3.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_4_9_3.cmake
@@ -1,9 +1,9 @@
-###############################################################################
-# Copyright (c) 2019, Lawrence Livermore National Security, LLC and other
-# RADIUSS-CI project contributors. See top-level COPYRIGHT file for details.
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: MIT
-###############################################################################
-
+# SPDX-License-Identifier: (MIT)
+##############################################################################
 set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/g++" CACHE PATH "")
 set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_6_1_0.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_6_1_0.cmake
@@ -1,9 +1,9 @@
-###############################################################################
-# Copyright (c) 2019, Lawrence Livermore National Security, LLC and other
-# RADIUSS-CI project contributors. See top-level COPYRIGHT file for details.
+##############################################################################
+# Copyright (c) 2016-19, Lawrence Livermore National Security, LLC and Umpire
+# project contributors. See the COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: MIT
-###############################################################################
-
+# SPDX-License-Identifier: (MIT)
+##############################################################################
 set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/g++" CACHE PATH "")
 set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_7_1_0.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/gcc_7_1_0.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/g++" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.1.0/bin/gfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_16_0_4.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_16_0_4.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/icpc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/icc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-16.0.4/bin/ifort" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_17_0_2.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_17_0_2.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/icpc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/icc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-17.0.2/bin/ifort" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_18_0_0.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/icpc_18_0_0.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/icpc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/icc" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.0/bin/ifort" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_17_10.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_17_10.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_C_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgcc" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgc++" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/pgi/pgi-17.10/bin/pgfortran" CACHE PATH "")

--- a/gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_18_5.cmake
+++ b/gitlab/conf/host-configs/toss_3_x86_64_ib/pgi_18_5.cmake
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################
-set(CMAKE_CXX_COMPILER "/usr/tcetmp/bin/g++" CACHE PATH "")
-set(CMAKE_C_COMPILER "/usr/tcetmp/bin/gcc" CACHE PATH "")
-set(CMAKE_Fortran_COMPILER "/usr/tcetmp/bin/gfortran" CACHE PATH "")
-
+set(CMAKE_C_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgcc" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgc++" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/pgi/pgi-18.5/bin/pgfortran" CACHE PATH "")


### PR DESCRIPTION
The use of these host-config files as at substitute to the one embedded in [Umpire](https://github.com/LLNL/Umpire) has been tested.

It’s time to merge. Or maybe we want to consider creating a specific repo? (@davidbeckingsale).